### PR TITLE
fix: change names on duplicated packages

### DIFF
--- a/MVC/src/com/caveofprogramming/designpattern/mvc/Application.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/Application.java
@@ -1,8 +1,8 @@
-package com.caveofprogramming.designpattern.demo1;
+package com.caveofprogramming.designpattern.mvc;
 
-import com.caveofprogramming.designpattern.demo1.controller.Controller;
-import com.caveofprogramming.designpattern.demo1.model.Model;
-import com.caveofprogramming.designpattern.demo1.view.View;
+import com.caveofprogramming.designpattern.mvc.controller.Controller;
+import com.caveofprogramming.designpattern.mvc.model.Model;
+import com.caveofprogramming.designpattern.mvc.view.View;
 
 import javax.swing.SwingUtilities;
 

--- a/MVC/src/com/caveofprogramming/designpattern/mvc/controller/Controller.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/controller/Controller.java
@@ -1,7 +1,9 @@
-package com.caveofprogramming.designpattern.demo1.controller;
+package com.caveofprogramming.designpattern.mvc.controller;
 
-import com.caveofprogramming.designpattern.demo1.model.Model;
-import com.caveofprogramming.designpattern.demo1.view.View;
+import com.caveofprogramming.designpattern.mvc.model.Model;
+import com.caveofprogramming.designpattern.mvc.view.LoginFormEvent;
+import com.caveofprogramming.designpattern.mvc.view.LoginListener;
+import com.caveofprogramming.designpattern.mvc.view.View;
 
 /**
  * This class handles the business logic of the application.
@@ -13,7 +15,7 @@ import com.caveofprogramming.designpattern.demo1.view.View;
  * The {@code Controller} sends commands to both the View and the Model. It is
  * almost certainly listening to the View, but may or may not listen to the Model.
  */
-public class Controller {
+public class Controller implements LoginListener {
     private final Model model;
     private final View view;
 
@@ -26,5 +28,13 @@ public class Controller {
     public Controller(View view, Model model) {
         this.view = view;
         this.model = model;
+    }
+
+    /**
+     * This is the implementation of the method defined in the LoginListener interface
+     */
+    @Override
+    public void loginPerform(LoginFormEvent event) {
+        System.out.println("Login event received: " + event.getName() + "; " + event.getPassword());
     }
 }

--- a/MVC/src/com/caveofprogramming/designpattern/mvc/model/Model.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/model/Model.java
@@ -1,4 +1,4 @@
-package com.caveofprogramming.designpattern.demo1.model;
+package com.caveofprogramming.designpattern.mvc.model;
 
 /**
  * This class deals with the data on the back end.

--- a/MVC/src/com/caveofprogramming/designpattern/mvc/view/LoginFormEvent.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/view/LoginFormEvent.java
@@ -1,4 +1,4 @@
-package com.caveofprogramming.designpattern.demo1.view;
+package com.caveofprogramming.designpattern.mvc.view;
 
 /**
  * This class is used to create an instance that stores data from

--- a/MVC/src/com/caveofprogramming/designpattern/mvc/view/LoginListener.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/view/LoginListener.java
@@ -1,4 +1,4 @@
-package com.caveofprogramming.designpattern.demo1.view;
+package com.caveofprogramming.designpattern.mvc.view;
 
 /**
  * This interface must be implemented by the Login Observer class.

--- a/MVC/src/com/caveofprogramming/designpattern/mvc/view/View.java
+++ b/MVC/src/com/caveofprogramming/designpattern/mvc/view/View.java
@@ -1,7 +1,6 @@
-package com.caveofprogramming.designpattern.demo1.view;
+package com.caveofprogramming.designpattern.mvc.view;
 
-import com.caveofprogramming.designpattern.demo1.controller.Controller;
-import com.caveofprogramming.designpattern.demo1.model.Model;
+import com.caveofprogramming.designpattern.mvc.model.Model;
 
 import javax.swing.*;
 import java.awt.*;

--- a/observer-pattern/src/com/caveofprogramming/designpattern/observer/Application.java
+++ b/observer-pattern/src/com/caveofprogramming/designpattern/observer/Application.java
@@ -1,8 +1,8 @@
-package com.caveofprogramming.designpattern.demo1;
+package com.caveofprogramming.designpattern.observer;
 
-import com.caveofprogramming.designpattern.demo1.controller.Controller;
-import com.caveofprogramming.designpattern.demo1.model.Model;
-import com.caveofprogramming.designpattern.demo1.view.View;
+import com.caveofprogramming.designpattern.observer.controller.Controller;
+import com.caveofprogramming.designpattern.observer.model.Model;
+import com.caveofprogramming.designpattern.observer.view.View;
 
 import javax.swing.*;
 

--- a/observer-pattern/src/com/caveofprogramming/designpattern/observer/controller/Controller.java
+++ b/observer-pattern/src/com/caveofprogramming/designpattern/observer/controller/Controller.java
@@ -1,9 +1,7 @@
-package com.caveofprogramming.designpattern.demo1.controller;
+package com.caveofprogramming.designpattern.observer.controller;
 
-import com.caveofprogramming.designpattern.demo1.model.Model;
-import com.caveofprogramming.designpattern.demo1.view.LoginFormEvent;
-import com.caveofprogramming.designpattern.demo1.view.LoginListener;
-import com.caveofprogramming.designpattern.demo1.view.View;
+import com.caveofprogramming.designpattern.observer.model.Model;
+import com.caveofprogramming.designpattern.observer.view.View;
 
 /**
  * This class handles the business logic of the application.
@@ -15,7 +13,7 @@ import com.caveofprogramming.designpattern.demo1.view.View;
  * The {@code Controller} sends commands to both the View and the Model. It is
  * almost certainly listening to the View, but may or may not listen to the Model.
  */
-public class Controller implements LoginListener {
+public class Controller {
     private final Model model;
     private final View view;
 
@@ -28,13 +26,5 @@ public class Controller implements LoginListener {
     public Controller(View view, Model model) {
         this.view = view;
         this.model = model;
-    }
-
-    /**
-     * This is the implementation of the method defined in the LoginListener interface
-     */
-    @Override
-    public void loginPerform(LoginFormEvent event) {
-        System.out.println("Login event received: " + event.getName() + "; " + event.getPassword());
     }
 }

--- a/observer-pattern/src/com/caveofprogramming/designpattern/observer/model/Model.java
+++ b/observer-pattern/src/com/caveofprogramming/designpattern/observer/model/Model.java
@@ -1,4 +1,4 @@
-package com.caveofprogramming.designpattern.demo1.model;
+package com.caveofprogramming.designpattern.observer.model;
 
 /**
  * This class deals with the data on the back end.

--- a/observer-pattern/src/com/caveofprogramming/designpattern/observer/view/View.java
+++ b/observer-pattern/src/com/caveofprogramming/designpattern/observer/view/View.java
@@ -1,6 +1,6 @@
-package com.caveofprogramming.designpattern.demo1.view;
+package com.caveofprogramming.designpattern.observer.view;
 
-import com.caveofprogramming.designpattern.demo1.model.Model;
+import com.caveofprogramming.designpattern.observer.model.Model;
 
 import javax.swing.*;
 import java.awt.*;


### PR DESCRIPTION
This PR renames two package with the same name, changing them from `demo1` to `mcv` and `observer`.  This ensures that the packages name correspond to the name of the example patterns they contain.